### PR TITLE
added prefix com.apple.CoreSimulator.SimDeviceType. for --devicetypeid a...

### DIFF
--- a/Source/iPhoneSimulator.m
+++ b/Source/iPhoneSimulator.m
@@ -22,6 +22,7 @@ NSString *deviceIpad = @"iPad";
 NSString *deviceIpadRetina = @"iPad Retina";
 NSString *deviceIpadRetina_64bit = @"iPad Retina (64-bit)";
 
+NSString* deviceTypeIdPrefix = @"com.apple.CoreSimulator.SimDeviceType.";
 NSString* deviceTypeIdIphone4s = @"com.apple.CoreSimulator.SimDeviceType.iPhone-4s";
 NSString* deviceTypeIdIphone5 = @"com.apple.CoreSimulator.SimDeviceType.iPhone-5";
 NSString* deviceTypeIdIphone5s = @"com.apple.CoreSimulator.SimDeviceType.iPhone-5s";
@@ -699,6 +700,9 @@ static void ChildSignal(int arg) {
       } else if (strcmp(argv[i], "--devicetypeid") == 0) {
           i++;
           deviceTypeId = [NSString stringWithUTF8String:argv[i]];
+          if (![deviceTypeId containsString:deviceTypeIdPrefix]) {
+              deviceTypeId = [deviceTypeIdPrefix stringByAppendingString:deviceTypeId];
+          }
       } else if (strcmp(argv[i], "--setenv") == 0) {
         i++;
         NSArray *parts = [[NSString stringWithUTF8String:argv[i]] componentsSeparatedByString:@"="];

--- a/Source/iPhoneSimulator.m
+++ b/Source/iPhoneSimulator.m
@@ -232,7 +232,7 @@ NSString* FindDeveloperDir() {
         SimDeviceSet* deviceSet = [simDeviceSet defaultSet];
         NSArray* devices = [deviceSet availableDevices];
         for (SimDevice* device in devices) {
-            nsfprintf(stdout, @"%@, %@", device.deviceType.identifier, device.runtime.versionString);
+            nsfprintf(stdout, @"%@,%@", [device.deviceType.identifier substringFromIndex:[device.deviceType.identifier rangeOfString:deviceTypeIdPrefix].length], device.runtime.versionString);
         }
     }
 


### PR DESCRIPTION
Commando iso-sim showdevicetypes return a list similar to this:

com.apple.CoreSimulator.SimDeviceType.iPhone-4s, 8.3
com.apple.CoreSimulator.SimDeviceType.iPhone-5, 8.3
com.apple.CoreSimulator.SimDeviceType.iPhone-5s, 8.3
com.apple.CoreSimulator.SimDeviceType.iPhone-6-Plus, 8.3
com.apple.CoreSimulator.SimDeviceType.iPhone-6, 8.3
com.apple.CoreSimulator.SimDeviceType.iPad-2, 8.3
com.apple.CoreSimulator.SimDeviceType.iPad-Retina, 8.3
com.apple.CoreSimulator.SimDeviceType.iPad-Air, 8.3
com.apple.CoreSimulator.SimDeviceType.Resizable-iPhone, 8.3
com.apple.CoreSimulator.SimDeviceType.Resizable-iPad, 8.3

It would be easier to just type the device name and pre-append the Prefix (com.apple.CoreSimulator.SimDeviceType.)

Before: ios-sim launch <App Path> com.apple.CoreSimulator.SimDeviceType.iPhone-6
After: ios-sim launch <App Path> iPhone-6

This PR is also backwards compatible.