### PR TITLE
Added Install command to provide option of installing without a launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Usage
       showdevicetypes                 List the available device types
       launch <application path>       Launch the application at the specified path on the iOS Simulator
       start                           Launch iOS Simulator without an app
+      install <application path>      Install the application at the specified path on the iOS Simulator without launching the app
 
     Options:
       --version                       Print the version of ios-sim

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -5,7 +5,7 @@ Commands:
   showdevicetypes                 List the available device types
   launch <application path>       Launch the application at the specified path on the iOS Simulator
   start                           Launch iOS Simulator without an app
-  install                         Install the application at the specified path on the iOS Simulator without launching the app
+  install <application path>      Install the application at the specified path on the iOS Simulator without launching the app
 
 Options:
   --version                       Print the version of ios-sim

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -5,6 +5,7 @@ Commands:
   showdevicetypes                 List the available device types
   launch <application path>       Launch the application at the specified path on the iOS Simulator
   start                           Launch iOS Simulator without an app
+  install                         Install the application at the specified path on the iOS Simulator without launching the app
 
 Options:
   --version                       Print the version of ios-sim

--- a/src/commands.js
+++ b/src/commands.js
@@ -314,6 +314,52 @@ var command_lib = {
             }
         });
     },
+
+    install : function(args) {
+        var wait_for_debugger = false,
+            app_identifier,
+            argv,
+            app_path,
+            info_plist_path;
+
+        if (args.argv.remain.length < 2) {
+            help();
+            process.exit(1);
+        }
+        
+        app_path = args.argv.remain[1];
+        info_plist_path = path.join(app_path,'Info.plist');
+        if (!fs.existsSync(info_plist_path)) {
+            console.error(info_plist_path + " file not found.");
+            process.exit(1);
+        }
+        
+        bplist.parseFile(info_plist_path, function(err, obj) {
+          
+            if (err) {
+              throw err;
+            }
+
+            app_identifier = obj[0].CFBundleIdentifier;
+            argv = args.args || [];
+
+            // get the deviceid from --devicetypeid
+            // --devicetypeid is a string in the form "devicetype, runtime_version" (optional: runtime_version)
+            var device = getDeviceFromDeviceTypeId(args.devicetypeid);
+            
+            // so now we have the deviceid, we can proceed
+            simctl.extensions.start(device.id);
+            simctl.install(device.id, app_path);
+            
+            simctl.extensions.log(device.id, args.log);
+            if (args.log) {
+                console.log(util.format("logPath: %s", path.resolve(args.log)));
+            }
+            if (args.exit) {
+                process.exit(0);
+            }
+        });
+    },
     
     start : function(args) {
         var device = {};


### PR DESCRIPTION
I encountered a need to have an app installed to a simulator without it being run so that my automated testing scripts opened the application for the first time. I found myself editing the source code and adding a function that was entirely the same as "launch" but without the `simctl.launch` command.

I considered adding a flag to the launch command, but I figured this was more clear. Not sure if pull requests with feature additions are accepted, but someone else might benefit from this change.