### PR TITLE
Fix for Xcode 7 runtimes that don't have devices

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -263,6 +263,11 @@ var lib = {
         var list = [];
         for (var deviceName in druntimes) {
             var runtimes = druntimes[ deviceName ];
+            
+            if (!(deviceName in name_id_map)) {
+                continue;
+            }
+            
             runtimes.forEach(function(runtime){
                 // remove "iOS" prefix in runtime, remove prefix "com.apple.CoreSimulator.SimDeviceType." in id
                 list.push(util.format("%s, %s", name_id_map[ deviceName ].replace(/^com.apple.CoreSimulator.SimDeviceType./, ''), runtime.replace(/^iOS /, '')));


### PR DESCRIPTION
Xcode 7 includes "Resizable iPad" and "Resizable iPhone" in the list of runtimes, but they don't have corresponding device types.

ios-sim would throw an error about calling `replace` on `undefined` due to failing to look up the device type in the name_id_map.

/cc @macdonst @shazron 