### PR TITLE
Removed plist argument from install function because it isn't used and caused the devicetypeid not to be recognized

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -334,7 +334,7 @@ var lib = {
         });
     },
 
-    install : function(app_path, info_plist_path, devicetypeid, log, exit) {
+    install : function(app_path, devicetypeid, log, exit) {
         var wait_for_debugger = false,
             info_plist_path,
             app_identifier;


### PR DESCRIPTION
The install function in lib.js was expecting as a second argument the
the Info.plist path but this is never passed and the function calculates
it based on the App path. This was causing that the devicetypeid not be
recognized even though it was being passed because it was passed as the
second argument to the function by the install function in commands.js

Software Versions:
1.MacOS version: 10.10.5
2. ios-sim version: 5.0.2
3. Xcode version: Xcode 7.0.1 Build version 7A1001
4. xcode-select: /Applications/Xcode.app/Contents/Developer
5. gcc version: Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/c++/4.2.1
Apple LLVM version 7.0.0 (clang-700.0.72)
Target: x86_64-apple-darwin14.5.0
Thread model: posix
