### PR TITLE
No more requirement to be installed on OS X.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "ios-sim",
   "version": "5.0.3",
-  "os" : [ "darwin" ],
   "preferGlobal": "true",
   "description": "launch iOS apps into the iOS Simulator from the command line (Xcode 6.0+)",
   "main": "ios-sim.js",


### PR DESCRIPTION
This stops NPM from refusing to install ios-sim on an OS other than OS X.

Right now I have a project where ios-sim is a dev-dependency, but developers on Linux can't even `npm install` the project now, because package.json's `os` field is preventing NPM from considering it a successful installation. I think the timing of that decision should be at runtime, not install time. Consider also that there may be people who want to install dependencies on Windows or Linux, and package the whole project, before using it on OSX.

The fact that there is no C/C++/ObjC code whatsoever in ios-sim shows that this can be installed on any platform without a problem.