### PR TITLE
Add ability to use non-binary plist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "author": "Shazron Abdullah",
   "license": "MIT",
   "dependencies": {
+      "plist": "^1.2.0",
       "simctl": "^0.0.9",
       "nopt": "1.0.9",
       "bplist-parser" : "^0.0.6"

--- a/src/lib.js
+++ b/src/lib.js
@@ -27,7 +27,8 @@ var path = require('path'),
     help = require('./help'),
     util = require('util'),
     simctl,
-    bplist;
+	bplist,
+	plist;
     
 function findFirstAvailableDevice(list) {
     /*
@@ -315,11 +316,21 @@ var lib = {
         bplist.parseFile(info_plist_path, function(err, obj) {
           
             if (err) {
-              throw err;
-            }
+				// try to see if a regular plist parser will work
+		        if (!plist) {
+		            plist = require('plist');
+		        }
+				obj = plist.parse(fs.readFileSync(info_plist_path, 'utf8'));
+				if (obj) {
+				  app_identifier = obj.CFBundleIdentifier;
+				} else {
+				  throw err;
+				}
+            } else {
+           		app_identifier = obj[0].CFBundleIdentifier;
+			}
 
-            app_identifier = obj[0].CFBundleIdentifier;
-            argv = argv || [];
+             argv = argv || [];
 
             // get the deviceid from --devicetypeid
             // --devicetypeid is a string in the form "devicetype, runtime_version" (optional: runtime_version)


### PR DESCRIPTION
Our app has an info.plist that is not binary.  This change allows both binary and non-binary plists to be read.