### PR TITLE
Add support for tvOS and watchOS

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -194,7 +194,7 @@ function getDeviceFromDeviceTypeId(devicetypeid) {
     }
 
     // prepend iOS to runtime version, if necessary
-    if (ret_obj.runtime.indexOf('iOS') === -1) {
+    if (ret_obj.runtime.indexOf('OS') === -1)
         ret_obj.runtime = util.format('iOS %s', ret_obj.runtime);
     }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -194,7 +194,7 @@ function getDeviceFromDeviceTypeId(devicetypeid) {
     }
 
     // prepend iOS to runtime version, if necessary
-    if (ret_obj.runtime.indexOf('OS') === -1)
+    if (ret_obj.runtime.indexOf('OS') === -1) {
         ret_obj.runtime = util.format('iOS %s', ret_obj.runtime);
     }
 


### PR DESCRIPTION
For tvOS and watchOS we do not need to prepend iOS string:

Example from device types:

> iPad-Pro, 10.3
> Apple-TV-1080p, tvOS 10.2
> Apple-Watch-38mm, watchOS 3.2