### PR TITLE
Remove process.exit when simctl prerequisite does not pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "preferGlobal": "true",
   "description": "launch iOS apps into the iOS Simulator from the command line (Xcode 7.0+)",
   "main": "ios-sim.js",

--- a/spec/lib.spec.js
+++ b/spec/lib.spec.js
@@ -51,6 +51,8 @@ describe('lib end-to-end', function() {
         });
     })
 
-    // it('', function(done) {
-    // });
+    it('init should not process.exit when called as a lib', function() {
+        var code = lib.init();
+        expect(!isNaN(code)).toBe(true);
+    });
 });

--- a/src/cli.js
+++ b/src/cli.js
@@ -37,7 +37,10 @@ var nopt;
 function init() {
     try {
         nopt = require('nopt');
-        command_lib.init();
+        var code = command_lib.init();
+        if (code !== 0) {
+            process.exit(code);
+        }
     } catch (e) {
         console.error(
             'Please run npm install from this directory:\n\t' +

--- a/src/commands.js
+++ b/src/commands.js
@@ -31,7 +31,7 @@ var path = require('path'),
 var command_lib = {
 
     init: function() {
-        lib.init();
+        return lib.init();
     },
 
     //jscs:disable disallowUnusedParams

--- a/src/lib.js
+++ b/src/lib.js
@@ -274,12 +274,13 @@ var lib = {
         var output = simctl.check_prerequisites();
         if (output.code !== 0) {
             console.error(output.output);
-            process.exit(2);
         }
 
         if (!bplist) {
             bplist = require('bplist-parser');
         }
+
+        return output.code;
     },
 
     //jscs:disable disallowUnusedParams


### PR DESCRIPTION
The init() function will return a shell return code. In the CLI context, when the return code is non-zero, it will then call process.exit with that return code.

Since the behaviour has changed, the version is bumped a major so that dependents don't pick this up automatically and encounter unexpected results.