### PR TITLE
Remove unnecessary call to fixSimCtlList in showsdks

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -326,7 +326,6 @@ var lib = {
     showsdks: function(args) {
         var options = { silent: true, runtimes: true };
         var list = simctl.list(options).json;
-        list = fixSimCtlList(list);
 
         console.log('Simulator SDK Roots:');
         list.runtimes.forEach(function(runtime) {


### PR DESCRIPTION
At the moment, a call to

    ios-sim showsdks

Fails to run with the error:

    Cannot convert undefined or null to object

The call to fixSimCtlList(...) is unrequired. This references two properties in regards to the simulators: `devicetypes` and `devices`. We are concerned with the SDKs, not simulators at this point, so the call is unnecessary.

More details in the bug report: #220.