### PR TITLE
It seems like iOS device names have changed again...

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -110,7 +110,7 @@ function findRuntimesGroupByDeviceProperty(list, deviceProperty, availableOnly) 
 function findAvailableRuntime(list, device_name) {
 
     var all_druntimes = findRuntimesGroupByDeviceProperty(list, 'name', true);
-    var druntime = all_druntimes[ filterDeviceName(device_name) ];
+    var druntime = all_druntimes[ device_name ];
     var runtime_found = druntime && druntime.length > 0;
 
     if (!runtime_found) {
@@ -199,7 +199,7 @@ function getDeviceFromDeviceTypeId(devicetypeid) {
         // found the runtime, now find the actual device matching devicename
         if (deviceGroup === ret_obj.runtime) {
             return list.devices[deviceGroup].some(function(device) {
-                if (filterDeviceName(device.name) === filterDeviceName(ret_obj.name)) {
+                if (device.name === ret_obj.name) {
                     ret_obj.id = device.udid;
                     return true;
                 }
@@ -255,15 +255,6 @@ function withInjectedEnvironmentVariablesToProcess(process, envVariables, action
 
     // restore old envs
     process.env = oldVariables;
-}
-
-// replace hyphens in iPad Pro name which differ in 'Device Types' and 'Devices'
-function filterDeviceName(deviceName) {
-    // replace hyphens in iPad Pro name which differ in 'Device Types' and 'Devices'
-    if (deviceName.indexOf('iPad Pro') === 0) {
-        return deviceName.replace(/\-/g, ' ').trim();
-    }
-    return deviceName;
 }
 
 function fixNameKey(array, mapping) {
@@ -349,7 +340,7 @@ var lib = {
         var name_id_map = {};
 
         list.devicetypes.forEach(function(device) {
-            name_id_map[ filterDeviceName(device.name) ] = device.identifier;
+            name_id_map[ device.name ] = device.identifier;
         });
 
         list = [];
@@ -366,9 +357,8 @@ var lib = {
 
         for (var deviceName in druntimes) {
             var runtimes = druntimes[ deviceName ];
-            var dname = filterDeviceName(deviceName);
 
-            if (!(dname in name_id_map)) {
+            if (!(deviceName in name_id_map)) {
                 continue;
             }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -110,7 +110,7 @@ function findRuntimesGroupByDeviceProperty(list, deviceProperty, availableOnly) 
 function findAvailableRuntime(list, device_name) {
 
     var all_druntimes = findRuntimesGroupByDeviceProperty(list, 'name', true);
-    var druntime = all_druntimes[ device_name ];
+    var druntime = all_druntimes[ filterDeviceName(device_name) ] || all_druntimes[ device_name ];
     var runtime_found = druntime && druntime.length > 0;
 
     if (!runtime_found) {
@@ -199,7 +199,7 @@ function getDeviceFromDeviceTypeId(devicetypeid) {
         // found the runtime, now find the actual device matching devicename
         if (deviceGroup === ret_obj.runtime) {
             return list.devices[deviceGroup].some(function(device) {
-                if (device.name === ret_obj.name) {
+                if (filterDeviceName(device.name) === filterDeviceName(ret_obj.name)) {
                     ret_obj.id = device.udid;
                     return true;
                 }
@@ -255,6 +255,15 @@ function withInjectedEnvironmentVariablesToProcess(process, envVariables, action
 
     // restore old envs
     process.env = oldVariables;
+}
+
+// replace hyphens in iPad Pro name which differ in 'Device Types' and 'Devices'
+function filterDeviceName(deviceName) {
+    // replace hyphens in iPad Pro name which differ in 'Device Types' and 'Devices'
+    if (deviceName.indexOf('iPad Pro') === 0) {
+        return deviceName.replace(/\-/g, ' ').trim();
+    }
+    return deviceName;
 }
 
 function fixNameKey(array, mapping) {
@@ -340,7 +349,7 @@ var lib = {
         var name_id_map = {};
 
         list.devicetypes.forEach(function(device) {
-            name_id_map[ device.name ] = device.identifier;
+            name_id_map[ filterDeviceName(device.name) ] = device.identifier;
         });
 
         list = [];
@@ -357,8 +366,9 @@ var lib = {
 
         for (var deviceName in druntimes) {
             var runtimes = druntimes[ deviceName ];
+            var dname = filterDeviceName(deviceName);
 
-            if (!(deviceName in name_id_map)) {
+            if (!(dname in name_id_map)) {
                 continue;
             }
 


### PR DESCRIPTION
On ios-sim 6.1.2 with XCode 9.0 and the iOS 11.0 runtime I get this error:

No available runtimes could be found for "iPad Pro (12.9-inch)".

I chase this all the way back to the fact that the devices now have a hypen again.

```
    iPad Pro (9.7-inch) (B22EE94B-DFB7-4E8E-9857-B5AFC3714C5A) (Shutdown)
    iPad Pro (12.9-inch) (B0157B87-16AB-4919-8BE1-96E740AAA794) (Booted)
    iPad Pro (12.9-inch) (2nd generation) (07A54F54-4C2A-4EB4-A3A1-6AEFEB1177A7) (Shutdown)
    iPad Pro (10.5-inch) (C04DED7A-E655-4F20-96D8-1D2EA9183E01) (Shutdown)
```

Getting rid of the device name filtering solves the problem.